### PR TITLE
Migrate to Streamlit 1.22.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM python:3.8.2-slim
+FROM python:3.9-slim
 
-WORKDIR /usr/app/src
+WORKDIR /app
 
 COPY requirements.txt requirements.txt
 
 RUN pip install -r requirements.txt
 
-COPY app ./
+COPY app .
 
-CMD ["sh", "-c", "streamlit run --server.port $PORT /usr/app/src/main.py"]
+ENV PORT 8000
+ENV HOST 0.0.0.0
+
+CMD [ "sh", "-c", "streamlit run --server.port ${PORT} --server.address ${HOST} /app/main.py" ]

--- a/app/src/state.py
+++ b/app/src/state.py
@@ -1,8 +1,10 @@
-from streamlit.report_thread import get_report_ctx
-from streamlit.hashing import _CodeHasher
-from streamlit.server.server import Server
+from streamlit.runtime.scriptrunner import get_script_run_ctx
+from streamlit.runtime.legacy_caching.hashing import _CodeHasher
+from streamlit.runtime import Runtime
+from streamlit.web.server.server import Server
 import streamlit as st
 from typing import Dict, Any
+from streamlit.runtime import get_instance
 from copy import deepcopy
 
 
@@ -59,14 +61,15 @@ class _SessionState:
                 self._state["data"], None
             ):
                 self._state["is_rerun"] = True
-                self._state["session"].request_rerun()
+                self._state["session"].request_rerun(None)
 
         self._state["hash"] = self._state["hasher"].to_bytes(self._state["data"], None)
 
 
 def _get_session():
-    session_id = get_report_ctx().session_id
-    session_info = Server.get_current()._get_session_info(session_id)
+    runtime = get_instance()
+    session_id = get_script_run_ctx().session_id
+    session_info = runtime._session_mgr.get_session_info(session_id)
 
     if session_info is None:
         raise RuntimeError("Couldn't get your Streamlit Session object.")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,10 @@ services:
     app:
         image: streamlit-docker
         build:
-            dockerfile: ./Dockerfile
-            context: .
+            dockerfile: Dockerfile
         environment:
             - PORT=${PORT}
         ports:
             - ${PORT}:${PORT}
         volumes:
-            - ./app:/usr/app/src/
+            - ./app:/app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-streamlit==0.71.0
+streamlit==1.22.0


### PR DESCRIPTION
What:
-
This PR removes the deprecated functionalities and updates the Streamlit to the latest available version.


Tests:
-
- [X] Built & Run Docker image locally
- [X] Built & Run with Docker Compose
- [X] Page 1 and Page 2 state changes
